### PR TITLE
Al recibo se llega a través de movimientos en la caja

### DIFF
--- a/app/controllers/recibos_controller.rb
+++ b/app/controllers/recibos_controller.rb
@@ -52,7 +52,7 @@ class RecibosController < ApplicationController
       if ok && @recibo.save && @recibo.pagar_o_cobrar_con(@causa)
 
         format.html { seguir_agregando_o_mostrar }
-        format.json { render action: 'show', status: :created, location: [@recibo.factura,@recibo] }
+        format.json { render action: 'show', status: :created, location: [@recibo.factura, @recibo] }
       else
         format.html { render action: 'new' }
         format.json { render json: @recibo.errors, status: :unprocessable_entity }

--- a/app/models/cuota.rb
+++ b/app/models/cuota.rb
@@ -104,4 +104,3 @@ class Cuota < ActiveRecord::Base
     end
   end
 end
-

--- a/test/controllers/recibos_controller_test.rb
+++ b/test/controllers/recibos_controller_test.rb
@@ -76,9 +76,9 @@ class RecibosControllerTest < ActionController::TestCase
     importe_permitido = @factura.saldo
 
     assert_difference('Recibo.count') do
-      post :create, 
-        factura_id: @factura, 
-        recibo: attributes_for( :recibo, importe: importe_permitido, factura_id: @factura), 
+      post :create,
+        factura_id: @factura,
+        recibo: attributes_for( :recibo, importe: importe_permitido, factura_id: @factura),
         causa_tipo: 'cheque-de-terceros',
         causa: {cheque_id: create(:cheque)}
     end
@@ -92,8 +92,9 @@ class RecibosControllerTest < ActionController::TestCase
   end
 
   test "muestra a través de su obra" do
-    recibo = create :recibo, factura: @factura
-    get :show, obra_id: recibo.obra, id: recibo
+    recibo_interno = @factura.obra.cajas.first.depositar!(Money.new(1000))
+
+    get :show, obra_id: @factura.obra, id: recibo_interno
     assert_response :success
   end
 


### PR DESCRIPTION
`obra.recibos` ahora busca a través de cajas y movimientos (por los recibos
internos :|) asique no se podía acceder al recibo en este test simplemente
asociándolo con una factura.
