### PR TITLE
Usar excepciones que sigan burbujeando

### DIFF
--- a/app/models/caja.rb
+++ b/app/models/caja.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 class Caja < ActiveRecord::Base
+  class ErrorEnDeposito < ActiveRecord::ActiveRecordError; end;
+  class ErrorEnExtraccion < ActiveRecord::ActiveRecordError; end;
 
   default_scope { where(archivada: false) }
 
@@ -117,7 +119,7 @@ class Caja < ActiveRecord::Base
       (cantidad <= total(cantidad.currency.iso_code) || chequera?)
       depositar(cantidad * -1, false)
     else
-      raise ActiveRecord::Rollback, 'Falló la extracción' if lanzar_excepcion
+      raise ErrorEnExtraccion, I18n.t('cajas.error_en_extraccion') if lanzar_excepcion
       invalido = movimientos.build monto: Money.new(0)
       invalido.errors.add(:monto, :no_hay_fondos_suficientes)
       invalido
@@ -144,7 +146,7 @@ class Caja < ActiveRecord::Base
     if movimiento = movimientos.build(monto: cantidad)
       movimiento
     else
-      raise ActiveRecord::Rollback, 'Falló el depósito' if lanzar_excepcion
+      raise ErrorEnDeposito, I18n.t('cajas.error_en_deposito') if lanzar_excepcion
     end
   end
 

--- a/config/locales/cp.yml
+++ b/config/locales/cp.yml
@@ -81,3 +81,6 @@ es:
           attributes:
             caja:
               debe_ser_una_cuenta: 'La caja debe ser una cuenta de banco'
+  cajas:
+    error_en_deposito: 'Falló el depósito'
+    error_en_extraccion: 'Falló la extracción'

--- a/test/controllers/cheques_controllers_test.rb
+++ b/test/controllers/cheques_controllers_test.rb
@@ -45,14 +45,11 @@ class ChequesControllerTest < ActionController::TestCase
   end
 
   test "paga" do
-    assert @cheque.cuenta = create(:cuenta), @cheque.errors
+    @cheque.cuenta = create(:cuenta, :con_fondos, monto: @cheque.monto)
     assert @cheque.save, @cheque.errors.messages
-    assert @cheque.reload, @cheque.errors
     patch :pagar, obra_id: @cheque.chequera.obra,
           caja_id: @cheque.chequera, id: @cheque
 
     assert_response :success
   end
-
-
 end

--- a/test/controllers/recibos_controller_test.rb
+++ b/test/controllers/recibos_controller_test.rb
@@ -126,6 +126,6 @@ class RecibosControllerTest < ActionController::TestCase
       delete :destroy, id: recibo, factura_id: @factura
     end
 
-    assert_redirected_to factura_path
+    assert_redirected_to factura_path(@factura)
   end
 end

--- a/test/models/caja/caja_depositos_test.rb
+++ b/test/models/caja/caja_depositos_test.rb
@@ -30,7 +30,7 @@ class CajaDepositosTest < ActiveSupport::TestCase
     no_movimientos = MiniTest::Mock.new.expect :build, false, [Hash]
 
     @caja.stub :movimientos, no_movimientos do
-      assert_raise ActiveRecord::Rollback do
+      assert_raise Caja::ErrorEnDeposito do
         @caja.depositar(Money.new(100), true)
       end
     end

--- a/test/models/caja/caja_extracciones_test.rb
+++ b/test/models/caja/caja_extracciones_test.rb
@@ -68,7 +68,7 @@ class CajaExtraccionesTest < ActiveSupport::TestCase
   end
 
   test 'extraer lanza excepciones opcionalmente' do
-    assert_raise ActiveRecord::Rollback do
+    assert_raise Caja::ErrorEnExtraccion do
       @caja.extraer(Money.new(100), true)
     end
   end

--- a/test/models/caja/caja_movimientos_test.rb
+++ b/test/models/caja/caja_movimientos_test.rb
@@ -31,10 +31,12 @@ class CajaMovimientosTest < ActiveSupport::TestCase
     create :movimiento, caja: @caja, monto: Money.new(100, 'EUR')
 
     assert_no_difference 'Movimiento.count' do
-      @recibo_interno = @caja.cambiar(Money.new(200, 'EUR'), Money.new(300))
+      assert_raise Caja::ErrorEnExtraccion do
+        @ningun_recibo_interno = @caja.cambiar(Money.new(200, 'EUR'), Money.new(300))
+      end
     end
 
-    assert_nil @recibo_interno
+    assert_nil @ningun_recibo_interno
   end
 
   test 'transferir dineros de una caja a otra' do


### PR DESCRIPTION
En caja, cuando fallaba una extracción o un depósito, se largaba una excepción
`ActiveRecord::Rollback`. Esto frenaba la transacción, pero la excepción se
descartaba ahí. O sea que los fallos se ignoraban silenciosamente.

Saben de alguna parte del código que requiera que no se rompa todo si
querés extraer de una caja sin fondos? No pude encontrar nada. El hecho de no
ignorar la excepción podría ser útil en los controladores, por ejemplo, para pasarle
el mensaje al usuario. No estoy seguro de si podemos usar directamente validaciones para esto..
