### PR TITLE
registrar un driver propio con opciones

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,3 +58,8 @@ class Capybara::Rails::TestCase
     load Rails.root.join('db/seeds.rb')
   end
 end
+
+# Registrando el driver podemos pasar opciones como el profile a usar
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new app, browser: :firefox, profile: ENV['PROFILE']
+end


### PR DESCRIPTION
para que los que usamos no-script podamos elegir un perfil preconfigurado en `.env`. El que no no-script por default en los profiles nuevos no debería tener que hacer nada
