### PR TITLE
Feature/fix generar factura

### DIFF
--- a/app/models/cuota.rb
+++ b/app/models/cuota.rb
@@ -51,10 +51,11 @@ class Cuota < ActiveRecord::Base
     indice
   end
 
-  # pagar la cuota genera una factura de cobro que el tercero adeuda
+  # Para pagar la cuota hay que generar una factura de cobro que el tercero adeuda
   def generar_factura(periodo = nil)
     unless factura.present?
       vencimiento_actual = self.vencimiento
+
       # si la cuota se paga antes de tiempo, el monto actualizado se
       # calcula al indice del mes actual en lugar del indice del mes de
       # vencimiento
@@ -65,15 +66,13 @@ class Cuota < ActiveRecord::Base
 
       Factura.transaction do
         # FIXME falta el número
-        self.factura = Factura.new(situacion: 'cobro',
-          importe_neto: monto_actualizado(periodo),
+        factura.create situacion: 'cobro', importe_neto: monto_actualizado(periodo),
           fecha: vencimiento_actual,
           fecha_pago: vencimiento_actual + 10.days,
           descripcion: descripcion,
           tipo: contrato_de_venta.tipo_factura,
           tercero: tercero,
-          obra: obra)
-        self.save
+          obra: obra
       end
     end
 

--- a/test/factories/cuota.rb
+++ b/test/factories/cuota.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     contrato_de_venta
 
     monto_original { Money.new rand(1000) }
-    vencimiento { Time.now.to_date + rand(30).days}
+    vencimiento { Date.today + rand(30).days}
     descripcion 'cuota de prueba'
   end
 end

--- a/test/models/cuota/cuota_con_contrato_test.rb
+++ b/test/models/cuota/cuota_con_contrato_test.rb
@@ -40,19 +40,6 @@ class CuotaConContratoTest < ActiveSupport::TestCase
     assert @cv.cuotas.vencidas.first.vencida?, @cv.cuotas.vencidas.inspect
   end
 
-  test 'las cuotas generan facturas de cobro' do
-    c = @cv.cuotas.first
-    f = c.generar_factura
-
-    assert_equal c.factura, f
-    assert f.cobro?
-    assert_equal c.monto_actualizado, f.importe_neto
-    assert_equal c.tercero, f.tercero
-    assert_equal c.obra, f.obra
-    assert_equal c.contrato_de_venta.tipo_factura, f.tipo
-    assert_equal c.vencimiento + 10.days, f.fecha_pago.to_date
-  end
-
   test 'las cuotas que no están vencidas se pagan al indice actual' do
     c = @cv.cuotas.sin_vencer.pendientes.sample
     refute c.vencida?, c.vencimiento

--- a/test/models/cuota/cuota_generar_facturas_test.rb
+++ b/test/models/cuota/cuota_generar_facturas_test.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+require 'test_helper'
+
+class CuotaGenerarFacturaTest < ActiveSupport::TestCase
+  setup do
+    @cuota = create(:cuota, vencimiento: Date.today)
+    @factura = @cuota.generar_factura
+  end
+
+  test 'genera su propia factura' do
+    assert_instance_of Factura, @factura
+    assert_equal @cuota.factura, @factura
+  end
+
+  test 'las facturas son de cobro' do
+    assert @factura.cobro?
+  end
+
+  test 'la factura cubre el monto de la cuota' do
+    assert_equal @cuota.monto_actualizado, @factura.importe_neto
+  end
+
+  test 'la factura se le cobra al mismo cliente' do
+    assert_equal @cuota.tercero, @factura.tercero
+  end
+
+  test 'la factura se relaciona con la obra de la cuota' do
+    assert_equal @cuota.obra, @factura.obra
+  end
+
+  test 'se mantiene el tipo de transacción del contrato' do
+    assert_equal @cuota.contrato_de_venta.tipo_factura, @factura.tipo
+  end
+
+  test 'hay un plazo de 10 días para pagar esa factura' do
+    assert_equal @cuota.vencimiento + 10.days, @factura.fecha_pago.to_date
+  end
+end

--- a/test/models/cuota/cuota_generar_facturas_test.rb
+++ b/test/models/cuota/cuota_generar_facturas_test.rb
@@ -35,4 +35,8 @@ class CuotaGenerarFacturaTest < ActiveSupport::TestCase
   test 'hay un plazo de 10 días para pagar esa factura' do
     assert_equal @cuota.vencimiento + 10.days, @factura.fecha_pago.to_date
   end
+
+  test 'si ya tiene factura no genera otra' do
+    assert_equal @factura, @cuota.generar_factura
+  end
 end


### PR DESCRIPTION
separé un test gigante en varios más entendibles y arreglé un bug en `cuota.generar_factura` que creaba una nueva factura aunque la cuota ya tuviera
